### PR TITLE
[DPS-1629] Update omniauth-auth0 gem to require custom JWK host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group :development do
 end
 
 group :test do
-  gem 'pry'
   gem 'guard-rspec', require: false
   gem 'listen', '~> 3.1.5'
   gem 'rack-test'

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ group :development do
 end
 
 group :test do
+  gem 'pry'
   gem 'guard-rspec', require: false
   gem 'listen', '~> 3.1.5'
   gem 'rack-test'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # OmniAuth Auth0
 
+## FORK ADDITIONS
+1. PASSTHRU PARAMETERS
+2. CUSTOM JWK HOST DOMAIN
+____
+
 An [OmniAuth](https://github.com/intridea/omniauth) strategy for authenticating with [Auth0](https://auth0.com). This strategy is based on the [OmniAuth OAuth2](https://github.com/omniauth/omniauth-oauth2) strategy. 
 
 **Important security note:** The parent library for this strategy currently has an unresolved security issue. Please see the discussion, including mitigations for Rails and non-Rails applications, [here](https://github.com/auth0/omniauth-auth0/issues/82).
@@ -68,6 +73,7 @@ provider
   ENV['AUTH0_CLIENT_ID'],
   ENV['AUTH0_CLIENT_SECRET'],
   ENV['AUTH0_DOMAIN'],
+  ENV['AUTH0_KEY_HOST'],
   {
     authorize_params: {
       scope: 'openid read:users write:order',

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -2,6 +2,7 @@ require 'base64'
 require 'uri'
 require 'json'
 require 'omniauth'
+require 'pry'
 
 module OmniAuth
   module Auth0
@@ -17,6 +18,7 @@ module OmniAuth
       #   options.client_secret - Application Client Secret.
       def initialize(options)
         @domain = uri_string(options.domain)
+        @key_host_uri = uri_string(options.key_host)
 
         # Use custom issuer if provided, otherwise use domain
         @issuer = @domain
@@ -103,7 +105,7 @@ module OmniAuth
       # Get a JWKS from the domain
       # @return void
       def jwks
-        jwks_uri = URI(@domain + '.well-known/jwks.json')
+        jwks_uri = URI(@key_host_uri + '.well-known/jwks.json')
         @jwks ||= json_parse(Net::HTTP.get(jwks_uri))
       end
 

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -2,7 +2,6 @@ require 'base64'
 require 'uri'
 require 'json'
 require 'omniauth'
-require 'pry'
 
 module OmniAuth
   module Auth0

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -19,6 +19,7 @@ module OmniAuth
         client_id
         client_secret
         domain
+        key_host
       ]
 
       # Setup client URLs used during authentication

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -10,6 +10,7 @@ describe OmniAuth::Auth0::JWTValidator do
   let(:client_id) { 'CLIENT_ID' }
   let(:client_secret) { 'CLIENT_SECRET' }
   let(:domain) { 'samples.auth0.com' }
+  let(:key_host) { 'custom-keys.business.com' }
   let(:future_timecode) { 32_503_680_000 }
   let(:past_timecode) { 303_912_000 }
   let(:jwks_kid) { 'NkJCQzIyQzRBMEU4NjhGNUU4MzU4RkY0M0ZDQzkwOUQ0Q0VGNUMwQg' }
@@ -264,7 +265,8 @@ describe OmniAuth::Auth0::JWTValidator do
     opts = OpenStruct.new(
       domain: opt_domain,
       client_id: client_id,
-      client_secret: client_secret
+      client_secret: client_secret,
+      key_host: key_host
     )
     opts[:issuer] = opt_issuer unless opt_issuer.nil?
 
@@ -307,7 +309,7 @@ describe OmniAuth::Auth0::JWTValidator do
   end
 
   def stub_jwks
-    stub_request(:get, 'https://samples.auth0.com/.well-known/jwks.json')
+    stub_request(:get, "https://#{key_host}/.well-known/jwks.json")
       .to_return(
         headers: { 'Content-Type' => 'application/json' },
         body: jwks.to_json,

--- a/spec/omniauth/auth0/jwt_validator_spec.rb
+++ b/spec/omniauth/auth0/jwt_validator_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'json'
 require 'jwt'
+require 'byebug'
 
 describe OmniAuth::Auth0::JWTValidator do
   #
@@ -254,19 +255,20 @@ describe OmniAuth::Auth0::JWTValidator do
         kid: jwks_kid
       }
       token = make_rs256_token(payload)
-      decoded_token = make_jwt_validator(opt_domain: domain).decode(token)
+      # Setting #opt_key_host equal to domain, so that it uses the correct stub for jwks.
+      decoded_token = make_jwt_validator(opt_domain: domain, opt_key_host: domain).decode(token)
       expect(decoded_token.first['sub']).to eq(sub)
     end
   end
 
   private
 
-  def make_jwt_validator(opt_domain: domain, opt_issuer: nil)
+  def make_jwt_validator(opt_key_host: key_host, opt_domain: domain, opt_issuer: nil)
     opts = OpenStruct.new(
       domain: opt_domain,
       client_id: client_id,
       client_secret: client_secret,
-      key_host: key_host
+      key_host: opt_key_host
     )
     opts[:issuer] = opt_issuer unless opt_issuer.nil?
 

--- a/spec/omniauth/strategies/auth0_spec.rb
+++ b/spec/omniauth/strategies/auth0_spec.rb
@@ -11,6 +11,7 @@ describe OmniAuth::Strategies::Auth0 do
   let(:client_id) { 'CLIENT_ID' }
   let(:client_secret) { 'CLIENT_SECRET' }
   let(:domain_url) { 'https://samples.auth0.com' }
+  let(:key_host) { 'custom-keys.business.com' }
   let(:application) do
     lambda do
       [200, {}, ['Hello.']]
@@ -21,7 +22,8 @@ describe OmniAuth::Strategies::Auth0 do
       application,
       client_id,
       client_secret,
-      domain_url
+      domain_url,
+      key_host
     )
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
     client_id = 'CLIENT_ID'
     secret = 'CLIENT_SECRET'
     domain = 'samples.auth0.com'
+    key_host = 'custom-keys.business.com'
     client_id = options.delete(:client_id) if options.key?(:client_id)
     secret = options.delete(:client_secret) if options.key?(:client_secret)
     domain = options.delete(:domain) if options.key?(:domain)
@@ -43,7 +44,7 @@ RSpec.configure do |config|
       end
 
       use OmniAuth::Builder do
-        provider :auth0, client_id, secret, domain, options
+        provider :auth0, client_id, secret, domain, key_host, options
       end
 
       get '/auth/auth0/callback' do


### PR DESCRIPTION
https://grandrounds.atlassian.net/browse/DPS-1629

This gem verifies tokens using JWK from the tenant domain. As with other services/gems, this should be supplied to the gem instead to allow a different domain to facilitate auth0 private cloud migration.

