### PR TITLE
DT-109: publish gem to private gemfury repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 jobs:
   run-tests:
     docker:
@@ -35,7 +36,15 @@ jobs:
             snyk monitor --org=auth0-sdks
             fi
           when: always
-
+  publish:
+    docker:
+      - image: cimg/ruby:2.7
+    steps:
+      - checkout
+      - run:
+          name: Build and publish gem to gemfury
+          command: ./.circleci/publish.sh
+          
 workflows:
   tests:
     jobs:
@@ -48,3 +57,14 @@ workflows:
           context: snyk-env 
           requires: 
             - run-tests
+      - publish:
+          requires:
+            - run-tests
+          context:
+            - dod-pypi
+          filters:
+            # only publish gem after cutting tag
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ -z "$GEMFURY_PUSH_TOKEN" ]; then
+    echo 'Environment variable GEMFURY_PUSH_TOKEN must be specified. Aborting.'
+    exit 1
+fi
+
+for file in `ls *.gemspec`; do
+    gem build $file
+done
+
+# Publish to Gemfury (based on: https://gemfury.com/help/upload-packages/#cURL)
+for file in `ls *.gem`; do
+    echo "Publishing new package version: ${file}"
+    curl --fail -F package=@${file} https://${GEMFURY_PUSH_TOKEN}@push.fury.io/doctorondemand/
+done

--- a/README.md
+++ b/README.md
@@ -181,3 +181,16 @@ Auth0 helps you to easily:
 ## License
 
 The OmniAuth Auth0 strategy is licensed under MIT - [LICENSE](LICENSE)
+
+## How to Create a Release
+
+Releases happen in CircleCI when a tag is pushed to the repository.
+
+To create a release, you will need to do the following:
+
+1. Change the version in `lib/omniauth-auth0/version.rb` to the new version and create a PR with the change.
+1. Once the PR is merged, switch to the master branch and `git pull`.
+1. `git tag <version from version.rb>`
+1. `git push origin --tags`
+
+CircleCI will see the tag push, build, and release a new version of the library.


### PR DESCRIPTION
Currently our private gems are installed from github using git, and this requires an additional setup step that involves creating a github token.

We’re planning to start installing our private gems from gemfury (a private gem repository) to avoid creating github tokens.

This PR starts publishing this repo's gem to gemfury to allow for this.

More details in this doc: https://docs.google.com/document/d/1jRcN13jN6Ws4kPj79087wK4HrJwnjeTES5etebcuDH0/edit