### PR TITLE
[DP-4148] Update CODEOWNERS to IAM

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@ConsultingMD/developer-platform
+*	@ConsultingMD/iam


### PR DESCRIPTION
The IAM team (the non-DX half of DP) should be the sole owners of this repo.