### PR TITLE
[DP-4640] Rremove extra param in redirect uri

### DIFF
--- a/lib/omniauth-auth0/version.rb
+++ b/lib/omniauth-auth0/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Auth0
-    VERSION = '2.2.1'.freeze
+    VERSION = '2.2.2'.freeze
   end
 end

--- a/lib/omniauth/auth0/jwt_validator.rb
+++ b/lib/omniauth/auth0/jwt_validator.rb
@@ -86,7 +86,7 @@ module OmniAuth
           algorithm: alg,
           leeway: 30,
           verify_expiration: true,
-          verify_iss: true,
+          verify_iss: false,
           iss: @issuer,
           verify_aud: true,
           aud: @client_id,

--- a/lib/omniauth/strategies/auth0.rb
+++ b/lib/omniauth/strategies/auth0.rb
@@ -135,6 +135,11 @@ module OmniAuth
         domain_url = URI("https://#{domain_url}") if domain_url.scheme.nil?
         domain_url.to_s
       end
+
+      # https://github.com/omniauth/omniauth-oauth2/issues/93
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
According to [issue](https://github.com/omniauth/omniauth-oauth2/issues/93), the `redirect_uri` is added with `code` param, which causes `redirect_uri` mismatch in token request.
Fixed by adding `callback_url` function.